### PR TITLE
Appendix Bitmark vs. ETH comparison

### DIFF
--- a/bitmark-appendix/bitmark-eth-comparison.md
+++ b/bitmark-appendix/bitmark-eth-comparison.md
@@ -1,15 +1,15 @@
-# Bitmark vs. Ethereum
+# Bitmark versus Ethereum
 
 The Bitmark Property System enables management of digital property rights, but the Ethereum blockchain has two Ethereum Improvement Proposals that can similarly organize and administer digital assets: ERC-20 standardizes the control and transfer of tokens on the Ethereum blockchain and may be used to manage fungible assets; while ERC-721 introduces standards for collectible and other non-fungible assets.
 
 So why use Bitmark instead of Ethereum?
 
 
-The simplest answer is that Bitmark was built for digital property management, while Ethereum is instead intended to enable distributed computing. Ethereum certainly can do an impressive number of different things, but Bitmark was optimized for this specific use case, and as a result  it is faster, more efficient, and cheaper to manage assets on the Bitmark blockchain than to use Ethereum, as the following tables demonstrate.
+The simplest answer is that Bitmark is for digital property management, while Ethereum is instead intended to enable distributed computing. Ethereum certainly can do an impressive number of different things, but Bitmark was optimized for this specific use case, and as a result  it is faster, more efficient, and cheaper to manage assets on the Bitmark blockchain than to use Ethereum.
 
 <br>
 
-**Bitmark vs ERC-20 for Fungible Assets:**
+**Bitmark versus ERC-20 for Fungible Assets:**
 
 | Token Creation | Bitmark | ERC-20 |
 |----------------|---------|--------|
@@ -26,7 +26,7 @@ The simplest answer is that Bitmark was built for digital property management, w
 
 <br>
 
-**Bitmark vs ERC-721 for Non-Fungible Assets:**
+**Bitmark versus ERC-721 for Non-Fungible Assets:**
 
 
 | Token Creation | Bitmark | ERC-721 |
@@ -48,4 +48,4 @@ High throughput, small storage, and low cost all make it much easier for Bitmark
 
 Bitmark also has advantages over Ethereum because it has been carefully honed to provide the exact services needed for managing digital assets: no less and no more. Where Etherereum creates a potentially inconsistent experience for its digital properties because some details such as meta field support and asset ownership history are managed by smart contract, Bitmark instead maintains this information as part of the core functionality of its blockchain. Ethereum also has additional security concerns created by the inclusion of a Turing-complete programming language: as has already been seen in cases like The DAO exploit and the Parity multi-sig wallet exploit on Ethereum, digital assets in smart contracts can be lost due to coding mistakes. In the Bitmark Property System, those assets are instead protected by Bitmark’s own well-tested and trusted code.
 
-Ethereum might be the choice for you if your digital assets are part of a complex ecosystem, tightly integrated with smart contracts and the decentralized computing power that is the heart of Ethereum’s expertise, but for everyone else, Bitmark is likely to provide a smoother, more economical, and more secure experience, because digital assets are our expertise — which is why institutions like UC Berkeley, KKFARM, and Chibitronics, as well as individuals, trust Bitmark to defend their property rights.
+Ethereum might be the choice for people whose digital assets are part of a complex ecosystem, tightly integrated with smart contracts and the decentralized computing power that is the heart of Ethereum’s expertise, but for everyone else, Bitmark is likely to provide a smoother, more economical, and more secure experience, because digital assets are our expertise — which is why institutions like UC Berkeley, KKFARM, and Chibitronics, as well as individuals, trust Bitmark to defend their property rights.

--- a/bitmark-appendix/bitmark-eth-comparison.md
+++ b/bitmark-appendix/bitmark-eth-comparison.md
@@ -1,0 +1,51 @@
+# Bitmark vs. Ethereum
+
+The Bitmark Property System enables management of digital property rights, but the Ethereum blockchain has two Ethereum Improvement Proposals that can similarly organize and administer digital assets: ERC-20 standardizes the control and transfer of tokens on the Ethereum blockchain and may be used to manage fungible assets; while ERC-721 introduces standards for collectible and other non-fungible assets.
+
+So why use Bitmark instead of Ethereum?
+
+
+The simplest answer is that Bitmark was built for digital property management, while Ethereum is instead intended to enable distributed computing. Ethereum certainly can do an impressive number of different things, but Bitmark was optimized for this specific use case, and as a result  it is faster, more efficient, and cheaper to manage assets on the Bitmark blockchain than to use Ethereum, as the following tables demonstrate.
+
+<br>
+
+**Bitmark vs ERC-20 for Fungible Assets:**
+
+| Token Creation | Bitmark | ERC-20 |
+|----------------|---------|--------|
+| Throughput: Create Token Ownership     | 66,666/hour   | 1,200/hour
+| Cost: Create 1 Type of Token Ownership | $0.297        | $6.343
+| Storage: Issue Token                   | 1,077 bytes   | 6,399 bytes
+
+<br>
+
+| Token Transference | Bitmark | ERC-20 |
+|--------------------|---------|--------|
+| Throughput: Transfer Token             | 100,000/hour  | 42,480/hour
+| Cost: Transfer Token                   | $0.223        | $0.769
+
+<br>
+
+**Bitmark vs ERC-721 for Non-Fungible Assets:**
+
+
+| Token Creation | Bitmark | ERC-721 |
+|----------------|---------|---------|
+| Throughput: Create Token Ownership     | 100,000/hour  | 8,880/hour
+| Cost: Create 1 Token Ownership         | $0.148        | $1.019
+| Storage: Token                         | 8,602 bytes   | 47,195 bytes
+
+<br>
+
+| Token Transference | Bitmark | ERC-721 |
+|--------------------|---------|---------|
+| Throughput: Transfer Token             | 121,200/hour  | 12,720/hour
+| Cost: Transfer Token                   | $0.223        | $0.731
+
+<br>
+
+High throughput, small storage, and low cost all make it much easier for Bitmark to operate at scale when managing digital assets.
+
+Bitmark also has advantages over Ethereum because it has been carefully honed to provide the exact services needed for managing digital assets: no less and no more. Where Etherereum creates a potentially inconsistent experience for its digital properties because some details such as meta field support and asset ownership history are managed by smart contract, Bitmark instead maintains this information as part of the core functionality of its blockchain. Ethereum also has additional security concerns created by the inclusion of a Turing-complete programming language: as has already been seen in cases like The DAO exploit and the Parity multi-sig wallet exploit on Ethereum, digital assets in smart contracts can be lost due to coding mistakes. In the Bitmark Property System, those assets are instead protected by Bitmark’s own well-tested and trusted code.
+
+Ethereum might be the choice for you if your digital assets are part of a complex ecosystem, tightly integrated with smart contracts and the decentralized computing power that is the heart of Ethereum’s expertise, but for everyone else, Bitmark is likely to provide a smoother, more economical, and more secure experience, because digital assets are our expertise — which is why institutions like UC Berkeley, KKFARM, and Chibitronics, as well as individuals, trust Bitmark to defend their property rights.


### PR DESCRIPTION
I copy the content of the Bitmark vs. ETH comparison which represents the Bitmark benchmark from the website revision to the documentation appendix. 