### PR TITLE
[docs]Correct titles & Re-organize and updates the learning-bitmark/quick-start/working-with-bitmark sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,34 @@
 
 ## [Learning Bitmark](/pages/learning-bitmark/README.md)
 
-**[Bitmark Property System Introduction](/pages/learning-bitmark/problem-we-are-trying-to-solve.md)**
+**[Property System Introduction](/pages/learning-bitmark/problem-we-are-trying-to-solve.md)**
 
-**[Bitmark Blockchain Introduction](/pages/learning-bitmark/bitmark-blockchain.md)**
+**[Blockchain Introduction](/pages/learning-bitmark/bitmark-blockchain.md)**
 
 **[Quick Start](/pages/learning-bitmark/quick-start/README.md)**
-* [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md#run-a-bitmark-node)
-* [Creating a Bitmark Account](/pages/learning-bitmark/quick-start/working-with-bitmarks/creating-bitmark-account.md)
-* [Registering Bitmark Certificates](/pages/learning-bitmark/quick-start/working-with-bitmarks/issuing-bitmarks.md)
-* [Transferring Bitmark Certificates](/pages/learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks.md)
-* [Using Bitmark Shares](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md)
+* [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md)
+* [Working with Bitmark](working-with-bitmark.md)
+* [Using the Bitmark app](using-bitmark-app.md)
+* [Using the SDK](using-sdk.md)
+* [Using the CLI](using-cli.md)
+* [CLI Payment](payment-for-bitmark-cli.md)
+* [Using Bitmark shares](using-bitmark-shares.md)
 
 **[Contributing to Bitmark](/pages/learning-bitmark/contributing-to-bitmark/README.md)**
+* [Software Development Process](bitmark-software-development-process.md)
 * [Bitmark Upgrade Proposal](/pages/learning-bitmark/contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](/pages/learning-bitmark/contributing-to-bitmark/bug-bounty-program.md)
 
-**[Bitmark Terms and Glossary](/pages/bitmark-references/terms-and-glossary/bitmark-terms-and-glossary.md)**
+**[Glossary](/pages/learning-bitmark/bitmark-terms-and-glossary.md)**
 
 <br>
 
 ## [Bitmark References](/pages/bitmark-references/README.md#bitmark-references)
 
-**[Tutorial For Node Setup](/pages/bitmark-references/node-setup/bitmark-node-setup.md)**
+**[Tutorial for Node setup](/pages/bitmark-references/node-setup/bitmark-node-setup.md)**
 
-**[Bitmark Node Software](/pages/bitmark-references/bitmark-node-software/README.md)**
-* [Bitmark Blockchain Overview](/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-overview.md)
+**[Node Software](/pages/bitmark-references/bitmark-node-software/README.md)**
+* [Blockchain Overview](/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-technical-overview.md)
 * [RPC Communication](/pages/bitmark-references/rpc-communication/README.md)
 * [Block Verification and Synchronization](/pages/bitmark-references/bitmark-node-software/block-verification-and-synchronization.md)
 * [Storage](/pages/bitmark-references/bitmark-node-software/node-modules.md)
@@ -35,7 +38,7 @@
 * [Payment Verification](/pages/bitmark-references/bitmark-node-software/payment-verification.md)
 * [Security](/pages/bitmark-references/bitmark-node-software/security.md)
 
-**[Bitmark SDK](/pages/bitmark-references/bitmark-sdk/README.md)**
+**[SDK](/pages/bitmark-references/bitmark-sdk/README.md)**
 * [Overview](/pages/bitmark-references/bitmark-sdk/bitmark-sdk-document.md)
 * [Getting Started](/pages/bitmark-references/bitmark-sdk/bitmark-sdk-document.md)
 * [Account](/pages/bitmark-references/bitmark-sdk/account.md)
@@ -44,14 +47,14 @@
 * [Store Seed](/pages/bitmark-references/bitmark-sdk/store-seed.md)
 * [Web Socket](/pages/bitmark-references/bitmark-sdk/websocket.md)
 
-**[Bitmark\-CLI](/pages/bitmark-references/bitmark-cli/README.md)**
+**[CLI](/pages/bitmark-references/bitmark-cli/README.md)**
 * [Quick Setup](/pages/bitmark-references/bitmark-cli/quick-setup.md)
-* [Bitmark\-CLI Command Reference](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
+* [Command Reference](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
 
 <br>
 
-## [Bitmark Appendix](/pages/bitmark-appendix/README.md#bitmark-appendix)
+## [Appendix](/pages/bitmark-appendix/README.md#bitmark-appendix)
 
 * [Bitmark versus Ethereum](/pages/bitmark-appendix/bitmark-eth-comparison.md)
 * [Bitmark shares](/pages/bitmark-appendix/bitmark-shares.md)
-* [Bitmark papers](/pages/bitmark-appendix/bitmark-papers.md)
+* [Papers](/pages/bitmark-appendix/bitmark-papers.md)

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 
 **[Quick Start](/pages/learning-bitmark/quick-start/README.md)**
 * [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md)
-* [Working with Bitmark](working-with-bitmark.md)
-* [Using the Bitmark app](using-bitmark-app.md)
-* [Using the SDK](using-sdk.md)
-* [Using the CLI](using-cli.md)
-* [CLI Payment](payment-for-bitmark-cli.md)
-* [Using Bitmark shares](using-bitmark-shares.md)
+* [Working with Bitmark](/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md)
+* [Using the Bitmark app](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md)
+* [Using the SDK](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md)
+* [Using the CLI](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md)
+* [CLI Payment](/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md)
+* [Using Bitmark shares](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md)
 
 **[Contributing to Bitmark](/pages/learning-bitmark/contributing-to-bitmark/README.md)**
-* [Software Development Process](bitmark-software-development-process.md)
+* [Software Development Process](/pages/learning-bitmark/contributing-to-bitmark/bitmark-software-development-process.md)
 * [Bitmark Upgrade Proposal](/pages/learning-bitmark/contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](/pages/learning-bitmark/contributing-to-bitmark/bug-bounty-program.md)
 

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -9,11 +9,11 @@ entries:
     folderitems:
 
     - title: Property System Introduction
-      url: /learning-bitmark/bitmark-property-system-introduction
+      url: /learning-bitmark/property-system-introduction
       output: web
 
     - title: Blockchain Introduction
-      url: /learning-bitmark/bitmark-blockchain
+      url: /learning-bitmark/blockchain
       output: web
 
       subfolders:
@@ -22,7 +22,7 @@ entries:
           subfolderitems:
 
             - title: Running a Node
-              url: /learning-bitmark/quick-start/simple-solution-for-node-setup
+              url: /learning-bitmark/quick-start/running-a-node
               output: web
 
             - title: Creating an Account
@@ -50,7 +50,7 @@ entries:
           subfolderitems:
 
             - title: Software Development Process
-              url: /learning-bitmark/contributing-to-bitmark/bitmark-software-development-process
+              url: /learning-bitmark/contributing-to-bitmark/software-development-process
               output: web
 
             - title: Bitmark Upgrade Proposals
@@ -62,7 +62,7 @@ entries:
               output: web
 
     - title: Terms and Glossary
-      url: /learning-bitmark/bitmark-terms-and-glossary
+      url: /learning-bitmark/glossary
       output: web
 
 
@@ -80,7 +80,7 @@ entries:
           subfolderitems:
 
           - title: Blockchain
-            url: /bitmark-references/bitmark-node-software/bitmark-blockchain-overview
+            url: /bitmark-references/bitmark-node-software/blockchain-overview
             output: web
 
           - title: RPC Communication
@@ -165,7 +165,7 @@ entries:
       output: web
 
     - title: White Papers
-      url: /bitmark-appendix/bitmark-papers
+      url: /bitmark-appendix/papers
       output: web
 
 

--- a/_data/sidebars/mydoc_sidebar.yml
+++ b/_data/sidebars/mydoc_sidebar.yml
@@ -25,24 +25,28 @@ entries:
               url: /learning-bitmark/quick-start/running-a-node
               output: web
 
-            - title: Creating an Account
-              url: /learning-bitmark/quick-start/working-with-bitmarks/creating-bitmark-account
+            - title: Working with Bitmark
+              url: /learning-bitmark/quick-start/working-with-bitmark
               output: web
 
-            - title: Registering Bitmark Certificates
-              url: /learning-bitmark/quick-start/working-with-bitmarks/issuing-bitmarks
+            - title: Using the Bitmark app
+              url: /learning-bitmark/quick-start/using-the-bitmark-app
               output: web
 
-            - title: Transferring Bitmark Certificates
-              url: /learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks
+            - title: Using the SDK
+              url: /learning-bitmark/quick-start/using-the-cli
               output: web
 
-            - title: Using Bitmark Shares
-              url: /learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares
+            - title: Using the CLI
+              url: /learning-bitmark/quick-start/using-the-cli
               output: web
 
-            - title: Paying for Transactions from the CLI
-              url: /learning-bitmark/quick-start/working-with-bitmarks/bitmark-cli-payment
+            - title: CLI payment
+              url: /learning-bitmark/quick-start/cli-payment
+              output: web
+
+            - title: Using Bitmark shares
+              url: /learning-bitmark/quick-start/using-bitmark-shares
               output: web
 
         - title: Contributing to Bitmark
@@ -61,7 +65,7 @@ entries:
               url: /learning-bitmark/contributing-to-bitmark/bug-bounty-program
               output: web
 
-    - title: Terms and Glossary
+    - title: Glossary
       url: /learning-bitmark/glossary
       output: web
 
@@ -70,7 +74,7 @@ entries:
     output: web, pdf
     folderitems:
 
-    - title: Tutorial For Node Setup
+    - title: Tutorial for Node setup
       url: /bitmark-references/node-setup/tutorial-for-node-setup
       output: web
 
@@ -79,7 +83,7 @@ entries:
           output: web
           subfolderitems:
 
-          - title: Blockchain
+          - title: Blockchain Overview
             url: /bitmark-references/bitmark-node-software/blockchain-overview
             output: web
 
@@ -148,7 +152,7 @@ entries:
             url: /bitmark-references/bitmark-cli/bitmark-cli-quick-setup
             output: web
 
-          - title: Bitmark-CLI Command Reference
+          - title: Command Reference
             url: /bitmark-references/bitmark-cli/bitmark-cli-command-reference
             output: web
 

--- a/pages/README.md
+++ b/pages/README.md
@@ -9,10 +9,12 @@
 
 **[Quick Start](/pages/learning-bitmark/quick-start/README.md)**
 * [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md)
-* [Creating Bitmark Accounts](/pages/learning-bitmark/quick-start/working-with-bitmarks/creating-bitmark-account.md)
-* [Registering Bitmark Certificates](/pages/learning-bitmark/quick-start/working-with-bitmarks/issuing-bitmarks.md)
-* [Transferring Bitmark Certificates](/pages/learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks.md)
-* [Working with Bitmark shares](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md)
+* [Working with Bitmark](working-with-bitmark.md)
+* [Using the Bitmark app](using-bitmark-app.md)
+* [Using the SDK](using-sdk.md)
+* [Using the CLI](using-cli.md)
+* [CLI Payment](payment-for-bitmark-cli.md)
+* [Using Bitmark shares](using-bitmark-shares.md)
 
 **[Contributing to Bitmark](/pages/learning-bitmark/contributing-to-bitmark/README.md)**
 * [Software Development Process](bitmark-software-development-process.md)

--- a/pages/README.md
+++ b/pages/README.md
@@ -9,12 +9,12 @@
 
 **[Quick Start](/pages/learning-bitmark/quick-start/README.md)**
 * [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md)
-* [Working with Bitmark](working-with-bitmark.md)
-* [Using the Bitmark app](using-bitmark-app.md)
-* [Using the SDK](using-sdk.md)
-* [Using the CLI](using-cli.md)
-* [CLI Payment](payment-for-bitmark-cli.md)
-* [Using Bitmark shares](using-bitmark-shares.md)
+* [Working with Bitmark](/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md)
+* [Using the Bitmark app](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md)
+* [Using the SDK](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md)
+* [Using the CLI](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md)
+* [CLI Payment](/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md)
+* [Using Bitmark shares](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md)
 
 **[Contributing to Bitmark](/pages/learning-bitmark/contributing-to-bitmark/README.md)**
 * [Software Development Process](bitmark-software-development-process.md)

--- a/pages/README.md
+++ b/pages/README.md
@@ -3,9 +3,9 @@
 
 ## [Learning Bitmark](/pages/learning-bitmark/README.md)
 
-**[Bitmark Property System Introduction](/pages/learning-bitmark/problem-we-are-trying-to-solve.md)**
+**[Property System Introduction](/pages/learning-bitmark/problem-we-are-trying-to-solve.md)**
 
-**[Bitmark Blockchain Introduction](/pages/learning-bitmark/bitmark-blockchain.md)**
+**[Blockchain Introduction](/pages/learning-bitmark/bitmark-blockchain.md)**
 
 **[Quick Start](/pages/learning-bitmark/quick-start/README.md)**
 * [Running a Bitmark Node](/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md)
@@ -15,19 +15,20 @@
 * [Working with Bitmark shares](/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md)
 
 **[Contributing to Bitmark](/pages/learning-bitmark/contributing-to-bitmark/README.md)**
+* [Software Development Process](bitmark-software-development-process.md)
 * [Bitmark Upgrade Proposal](/pages/learning-bitmark/contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](/pages/learning-bitmark/contributing-to-bitmark/bug-bounty-program.md)
 
-**[Bitmark Terms and Glossary](/pages/bitmark-references/terms-and-glossary/bitmark-terms-and-glossary.md)**
+**[Glossary](/pages/learning-bitmark/bitmark-terms-and-glossary.md)**
 
 <br>
 
 ## [Bitmark References](/pages/bitmark-references/README.md#bitmark-references)
 
-**[Bitmark Node Setup](/pages/bitmark-references/node-setup/bitmark-node-setup.md)**
+**[Tutorial for Node setup](/pages/bitmark-references/node-setup/bitmark-node-setup.md)**
 
-**[Bitmark Node Software](/pages/bitmark-references/bitmark-node-software/README.md)**
-* [Bitmark Blockchain Technical Overview](/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-technical-overview.md)
+**[Node Software](/pages/bitmark-references/bitmark-node-software/README.md)**
+* [Blockchain Overview](/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-technical-overview.md)
 * [RPC Communication](/pages/bitmark-references/rpc-communication/README.md)
 * [Block Verification and Synchronization](/pages/bitmark-references/bitmark-node-software/block-verification-and-synchronization.md)
 * [Storage](/pages/bitmark-references/bitmark-node-software/node-modules.md)
@@ -35,7 +36,7 @@
 * [Payment Verification](/pages/bitmark-references/bitmark-node-software/payment-verification.md)
 * [Security](/pages/bitmark-references/bitmark-node-software/security.md)
 
-**[Bitmark SDK](/pages/bitmark-references/bitmark-sdk/README.md)**
+**[SDK](/pages/bitmark-references/bitmark-sdk/README.md)**
 * [Overview](/pages/bitmark-references/bitmark-sdk/bitmark-sdk-document.md)
 * [Getting Started](/pages/bitmark-references/bitmark-sdk/bitmark-sdk-document.md)
 * [Account](/pages/bitmark-references/bitmark-sdk/account.md)
@@ -44,14 +45,14 @@
 * [Store Seed](/pages/bitmark-references/bitmark-sdk/store-seed.md)
 * [Web Socket](/pages/bitmark-references/bitmark-sdk/websocket.md)
 
-**[Bitmark\-CLI](/pages/bitmark-references/bitmark-cli/README.md)**
+**[CLI](/pages/bitmark-references/bitmark-cli/README.md)**
 * [Quick Setup](/pages/bitmark-references/bitmark-cli/quick-setup.md)
-* [Bitmark\-CLI Command Reference](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
+* [Command Reference](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
 
 <br>
 
-## [Bitmark Appendix](/pages/bitmark-appendix/README.md#bitmark-appendix)
+## [Appendix](/pages/bitmark-appendix/README.md#bitmark-appendix)
 
 * [Bitmark versus Ethereum](/pages/bitmark-appendix/bitmark-eth-comparison.md)
 * [Bitmark shares](/pages/bitmark-appendix/bitmark-shares.md)
-* [Bitmark papers](/pages/bitmark-appendix/bitmark-papers.md)
+* [Papers](/pages/bitmark-appendix/bitmark-papers.md)

--- a/pages/bitmark-appendix/bitmark-papers.md
+++ b/pages/bitmark-appendix/bitmark-papers.md
@@ -1,5 +1,5 @@
 ---
-title: Bitmark Papers
+title: Papers
 keywords: papers
 last_updated: 
 sidebar: mydoc_sidebar
@@ -8,7 +8,7 @@ folder: bitmark-appendix
 ---
 
 
-# Bitmark Papers
+# Papers
 
 ## Bitmark: The property system for the digital environment
 

--- a/pages/bitmark-references/README.md
+++ b/pages/bitmark-references/README.md
@@ -10,9 +10,9 @@ _The Bitmark References offer you an encyclopedia of features for the Bitmark Pr
 * [Downloading and Installing a Bitmark Node](node-setup/bitmark-node-setup.md#downloading-and-installing-a-bitmark-node)
 * [Setting Up and Running a Bitmark Node](node-setup/bitmark-node-setup.md#setting-up-and-running-a-bitmark-node)
 
-## [Bitmark Node Software](bitmark-node-software/README.md)
+## [Node Software](bitmark-node-software/README.md)
 
-* [Bitmark Blockchain Technical Overview](bitmark-node-software/bitmark-blockchain-overview.md)
+* [Bitmark Blockchain Overview](bitmark-node-software/bitmark-blockchain-overview.md)
 * [Block Validation and Synchronization](bitmark-node-software/block-verification-and-synchronization.md)
 * [Block Mining](bitmark-node-software/mining.md)
 * [RPC Communication](bitmark-node-software/rpc-communication.md)
@@ -21,7 +21,7 @@ _The Bitmark References offer you an encyclopedia of features for the Bitmark Pr
 * [Blockchain Security](bitmark-node-software/security.md)
 
 
-## [Bitmark SDK](bitmark-sdk/README.md)
+## [SDK](bitmark-sdk/README.md)
 
 * [Overview and Getting started](bitmark-sdk/bitmark-sdk-document.md)
 * [Account](bitmark-sdk/account.md)
@@ -31,8 +31,8 @@ _The Bitmark References offer you an encyclopedia of features for the Bitmark Pr
 * [Web Socket](bitmark-sdk/web-socket.md)
 
 
-## [Bitmark\-CLI](bitmark-cli/README.md)
+## [CLI](bitmark-cli/README.md)
 
 * [Quick Setup](bitmark-cli/quick-setup.md)
-* [Bitmark\-CLI](bitmark-cli/bitmark-cli.md)
+* [Command Reference](bitmark-cli/bitmark-cli.md)
 

--- a/pages/bitmark-references/README.md
+++ b/pages/bitmark-references/README.md
@@ -3,7 +3,7 @@
 
 _The Bitmark References offer you an encyclopedia of features for the Bitmark Property System that can be used for reference purposes._
 
-## [Bitmark Node Setup](node-setup/bitmark-node-setup.md)
+## [Tutorial for Node setup](node-setup/bitmark-node-setup.md)
   
 * [Prerequisites](node-setup/bitmark-node-setup.md#prerequisites)
 * [Installing the Prerequisite Packages](node-setup/bitmark-node-setup.md#installing-the-prerequisite-packages)

--- a/pages/bitmark-references/bitmark-cli/README.md
+++ b/pages/bitmark-references/bitmark-cli/README.md
@@ -6,7 +6,7 @@
 * [Adding extra connections](quick-setup.md#adding-extra-connections)
 
 
-## [Bitmark\-CLI Command Reference](bitmark-cli.md#bitmark-cli-command-reference)
+## [Command Reference](bitmark-cli.md#command-reference)
   
 * [Basic Command Structure](bitmark-cli.md#basic-command-structure)
 * [Global Options](bitmark-cli.md#global-options)

--- a/pages/bitmark-references/bitmark-cli/bitmark-cli.md
+++ b/pages/bitmark-references/bitmark-cli/bitmark-cli.md
@@ -1,5 +1,5 @@
 ---
-title: Bitmark-CLI Command Reference
+title: Command Reference
 keywords: cli, bitmark-cli, command line interface
 last_updated: 
 sidebar: mydoc_sidebar
@@ -7,7 +7,7 @@ permalink: /bitmark-references/bitmark-cli/bitmark-cli-command-reference
 folder: bitmark-references/bitmark-cli
 ---
 
-# bitmark-cli Command Reference
+# Command Reference
 
 ## Basic Command Structure
 

--- a/pages/bitmark-references/bitmark-cli/quick-setup.md
+++ b/pages/bitmark-references/bitmark-cli/quick-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Bitmark-CLI Quick Setup
+title: Quick Setup
 keywords: cli, bitmark-cli, command line interface, quick setup
 last_updated: 
 sidebar: mydoc_sidebar

--- a/pages/bitmark-references/bitmark-node-software/README.md
+++ b/pages/bitmark-references/bitmark-node-software/README.md
@@ -2,7 +2,7 @@
 # Bitmark Node Software
 
 
-## [Bitmark Blockchain Technical Overview](bitmark-blockchain-overview.md)
+## [Blockchain](bitmark-blockchain-overview.md)
 
 * [Definitions](bitmark-blockchain-overview.md#definitions)
 * [Transactions: Asset, Issue and Transfer Records](bitmark-blockchain-overview.md#transactions-asset-issue-and-transfer-records)

--- a/pages/bitmark-references/bitmark-node-software/README.md
+++ b/pages/bitmark-references/bitmark-node-software/README.md
@@ -2,7 +2,7 @@
 # Bitmark Node Software
 
 
-## [Blockchain](bitmark-blockchain-overview.md)
+## [Blockchain Overview](bitmark-blockchain-overview.md)
 
 * [Definitions](bitmark-blockchain-overview.md#definitions)
 * [Transactions: Asset, Issue and Transfer Records](bitmark-blockchain-overview.md#transactions-asset-issue-and-transfer-records)

--- a/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-overview.md
+++ b/pages/bitmark-references/bitmark-node-software/bitmark-blockchain-overview.md
@@ -1,15 +1,15 @@
 ---
-title: Bitmark Blockchain Technical Overview
+title: Blockchain Overview
 keywords: blockchain
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /bitmark-references/bitmark-node-software/bitmark-blockchain-overview
+permalink: /bitmark-references/bitmark-node-software/blockchain-overview
 folder: bitmark-references/bitmark-node-software
 ---
 
-# Bitmark Blockchain Technical Overview
+# Blockchain Overview
 
-This brief description of the structure of the structure of the Bitmark blockchain moves
+This brief description of the structure of the Bitmark blockchain moves
 from the transactions up to the final structure of the chain
 itself.
 

--- a/pages/bitmark-references/node-setup/README.md
+++ b/pages/bitmark-references/node-setup/README.md
@@ -1,5 +1,5 @@
 
-# [Bitmark Node Installation](bitmark-node-setup.md#tutorial-for-node-setup)
+# [Tutorial for Node setup](bitmark-node-setup.md#tutorial-for-node-setup)
 
 ## [Prerequisites](bitmark-node-setup.md#prerequisites)
   

--- a/pages/bitmark-references/node-setup/bitmark-node-setup.md
+++ b/pages/bitmark-references/node-setup/bitmark-node-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Bitmark Node Installation
+title: Tutorial for Node setup
 keywords: node, node setup
 last_updated: 
 sidebar: mydoc_sidebar
@@ -7,9 +7,9 @@ permalink: /bitmark-references/node-setup/tutorial-for-node-setup
 folder: bitmark-references/node-setup
 ---
 
-#  Bitmark Node Installation
+#  Tutorial for Node setup
 
-The [Bitmark Quickstart](../../learning-bitmark/quick-start) includes a tutorial on [installing the Bitmark Property System using docker](../../learning-bitmark/quick-start/simple-solution-for-node-setup.md). That setup is intended for beginners who want to make it fast and easy to run the Bitmark Property System using a `docker` container that wraps all components and settings. Developers, or people who want to study the main program, may instead choose to run `bitmarkd` or `recorderd` services directly. 
+The **Bitmark Quickstart** includes a tutorial on [installing a Bitmark Node using docker](../../learning-bitmark/quick-start/simple-solution-for-node-setup.md). That setup is intended for beginners who want to make it fast and easy to run a Bitmark Node using a `docker` container that wraps all components and settings. Developers, or people who want to study the main program, may instead choose to run `bitmarkd` or `recorderd` services directly. 
 
 A full-node of bitmarkd consists of a `bitmarkd`, a `recorderd`, a payment system, a `litecoind`, and a `bitcoind`. The `bitmarkd` service  verifies and records transactions on the Bitmark blockchain while the `recorderd` service computes the Bitmark proof-of-work algorithm that allows nodes to compete to win blocks on the Bitmark blockchain. 
 

--- a/pages/learning-bitmark/README.md
+++ b/pages/learning-bitmark/README.md
@@ -17,10 +17,12 @@ _Learning Bitmark provides an introduction to the Bitmark Property System, inclu
 ## [Quick Start](quick-start/README.md#quick-start)
 
 * [Running a Bitmark Node](quick-start/simple-solution-for-node-setup.md#run-a-bitmark-node)
-* [Creating Bitmark Accounts](quick-start/working-with-bitmarks/creating-bitmark-account.md)
-* [Registering Bitmark Certificates](quick-start/working-with-bitmarks/issuing-bitmarks.md)
-* [Transferring Bitmark Certificates](quick-start/working-with-bitmarks/transferring-bitmarks.md)
-* [Working with Bitmark shares](quick-start//working-with-bitmarks/using-bitmark-shares.md)
+* [Working with Bitmark](working-with-bitmark.md)
+* [Using the Bitmark app](using-bitmark-app.md)
+* [Using the SDK](using-sdk.md)
+* [Using the CLI](using-cli.md)
+* [CLI Payment](payment-for-bitmark-cli.md)
+* [Using Bitmark shares](using-bitmark-shares.md)
 
 ## [Contributing to Bitmark](contributing-to-bitmark/README.md)
 
@@ -28,5 +30,4 @@ _Learning Bitmark provides an introduction to the Bitmark Property System, inclu
 * [Bitmark Upgrade Proposal](contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](contributing-to-bitmark/bug-bounty-program.md)
 
-## [Bitmark Terms and Glossary](bitmark-terms-and-glossary.md)
-* [Bitmark Terms and Glossary](bitmark-terms-and-glossary.md)
+## [Glossary](bitmark-terms-and-glossary.md)

--- a/pages/learning-bitmark/README.md
+++ b/pages/learning-bitmark/README.md
@@ -3,13 +3,13 @@
 
 _Learning Bitmark provides an introduction to the Bitmark Property System, including tutorial-style documents that will take you step by step through the basic Bitmark Property System features._
 
-## [Bitmark Property System Introduction](problem-we-are-trying-to-solve.md#bitmark-property-system-introduction)
+## [Property System Introduction](problem-we-are-trying-to-solve.md#property-system-introduction)
   
 * [The Power of Property Systems](problem-we-are-trying-to-solve.md#the-power-of-property-systems)
 * [Bitmark's Property System](problem-we-are-trying-to-solve.md#bitmarks-property-system)
 * [Bitmark's Technology](problem-we-are-trying-to-solve.md#bitmarks-technology)
 
-## [Bitmark Blockchain Introduction](bitmark-blockchain.md)
+## [Blockchain Introduction](bitmark-blockchain.md)
 
 * [Technical Overview](bitmark-blockchain.md#technical-overview)
 * [Technical FAQ](bitmark-blockchain.md#technical-faq)
@@ -24,6 +24,7 @@ _Learning Bitmark provides an introduction to the Bitmark Property System, inclu
 
 ## [Contributing to Bitmark](contributing-to-bitmark/README.md)
 
+* [Software Development Process](bitmark-software-development-process.md#software-development-process)
 * [Bitmark Upgrade Proposal](contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](contributing-to-bitmark/bug-bounty-program.md)
 

--- a/pages/learning-bitmark/README.md
+++ b/pages/learning-bitmark/README.md
@@ -17,16 +17,16 @@ _Learning Bitmark provides an introduction to the Bitmark Property System, inclu
 ## [Quick Start](quick-start/README.md#quick-start)
 
 * [Running a Bitmark Node](quick-start/simple-solution-for-node-setup.md#run-a-bitmark-node)
-* [Working with Bitmark](working-with-bitmark.md)
-* [Using the Bitmark app](using-bitmark-app.md)
-* [Using the SDK](using-sdk.md)
-* [Using the CLI](using-cli.md)
-* [CLI Payment](payment-for-bitmark-cli.md)
-* [Using Bitmark shares](using-bitmark-shares.md)
+* [Working with Bitmark](quick-start/working-with-bitmarks/working-with-bitmark.md)
+* [Using the Bitmark app](quick-start/working-with-bitmarks/using-bitmark-app.md)
+* [Using the SDK](quick-start/working-with-bitmarks/using-sdk.md)
+* [Using the CLI](quick-start/working-with-bitmarks/using-cli.md)
+* [CLI Payment](quick-start/working-with-bitmarks/payment-for-bitmark-cli.md)
+* [Using Bitmark shares](quick-start/working-with-bitmarks/using-bitmark-shares.md)
 
 ## [Contributing to Bitmark](contributing-to-bitmark/README.md)
 
-* [Software Development Process](bitmark-software-development-process.md#software-development-process)
+* [Software Development Process](contributing-to-bitmark/bitmark-software-development-process.md)
 * [Bitmark Upgrade Proposal](contributing-to-bitmark/bup.md)
 * [Bug Bounty Program](contributing-to-bitmark/bug-bounty-program.md)
 

--- a/pages/learning-bitmark/bitmark-blockchain.md
+++ b/pages/learning-bitmark/bitmark-blockchain.md
@@ -1,13 +1,13 @@
 ---
-title: Bitmark Blockchain Introduction
+title: Blockchain Introduction
 keywords: blockchain
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/bitmark-blockchain
+permalink: /learning-bitmark/blockchain-introduction
 folder: learning-bitmark
 ---
 
-# Bitmark Blockchain Introduction
+# Blockchain Introduction
 
 ## Technical Overview
 

--- a/pages/learning-bitmark/bitmark-terms-and-glossary.md
+++ b/pages/learning-bitmark/bitmark-terms-and-glossary.md
@@ -1,13 +1,13 @@
 ---
-title: Bitmark Glossary
+title: Glossary
 keywords: terms, glossary
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/bitmark-terms-and-glossary
+permalink: /learning-bitmark/glossary
 folder: learning-bitmark
 ---
 
-# Bitmark Glossary
+# Glossary
 
 **Account** — _See Bitmark Account._
 

--- a/pages/learning-bitmark/contributing-to-bitmark/README.md
+++ b/pages/learning-bitmark/contributing-to-bitmark/README.md
@@ -1,5 +1,7 @@
 # Contributing to Bitmark
 
+## [Software Development Process](bitmark-software-development-process.md#software-development-process)
+
 ## [Bitmark Upgrade Proposal](bup.md#bitmark-upgrade-proposal)
   
 * [What is a BUP?](bup.md#what-is-a-bup)

--- a/pages/learning-bitmark/contributing-to-bitmark/bitmark-software-development-process.md
+++ b/pages/learning-bitmark/contributing-to-bitmark/bitmark-software-development-process.md
@@ -1,13 +1,15 @@
 ---
-title: Bitmark Software Development Process
+title: Software Development Process
 keywords: development process, work flow
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/contributing-to-bitmark/bitmark-software-development-process
+permalink: /learning-bitmark/contributing-to-bitmark/software-development-process
 folder: learning-bitmark/contributing-to-bitmark
 ---
 
-# Current development workflow
+# Software Development Process
+
+## Current development workflow
 
 **Right now we have these projects:**
 * bitmarkd
@@ -36,7 +38,7 @@ We have a peer review process, where the developer can assign one or more indivi
 
 ![](/assets/images/review-process.png)
 
-# Development work-flow improvements
+## Development work-flow improvements
 
 **Development process:**
 

--- a/pages/learning-bitmark/contributing-to-bitmark/bup.md
+++ b/pages/learning-bitmark/contributing-to-bitmark/bup.md
@@ -8,6 +8,7 @@ folder: learning-bitmark/contributing-to-bitmark
 ---
 
 # Bitmark Upgrade Proposal
+
 ## What is a BUP?
 A Bitmark Upgrade Proposal (BUP) is a design document providing
 information to the Bitmark community or describing a new feature for

--- a/pages/learning-bitmark/problem-we-are-trying-to-solve.md
+++ b/pages/learning-bitmark/problem-we-are-trying-to-solve.md
@@ -1,13 +1,13 @@
 ---
-title: Bitmark Property System Introduction
+title: Property System Introduction
 keywords: introduction, property system
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/bitmark-property-system-introduction
+permalink: /learning-bitmark/property-system-introduction
 folder: learning-bitmark
 ---
 
-# Bitmark Property System Introduction
+# Property System Introduction
 
 Digital assets and data feel ephemeral: it is easy to lose track of your digital assets, and it is easy to let social networks and other content aggregators claim ownership over your data. Hackers and bots can steal your digital properties, and today you have little recourse to recover them.
 

--- a/pages/learning-bitmark/quick-start/README.md
+++ b/pages/learning-bitmark/quick-start/README.md
@@ -13,8 +13,9 @@
 
 ## [Working with bitmarks](working-with-bitmarks/README.md#working-with-bitmarks)
 
-* [Creating a Bitmark Account](working-with-bitmarks/creating-bitmark-account.md#creating-bitmark-account)
-* [Registering Bitmark Certificates](working-with-bitmarks/issuing-bitmarks.md#registering-bitmark-certificates)
-* [Transferring Bitmark Certificates](working-with-bitmarks/transferring-bitmarks.md#transferring-bitmark-certificates)
-* [Working with Bitmark Shares](working-with-bitmarks/using-bitmark-shares.md#bitmark-shares)
-* [Paying for Bitmark Transactions](working-with-bitmarks/payment-for-bitmark-cli.md)
+* [Working with Bitmark](working-with-bitmark.md)
+* [Using the Bitmark app](using-bitmark-app.md)
+* [Using the SDK](using-sdk.md)
+* [Using the CLI](using-cli.md)
+* [CLI Payment](payment-for-bitmark-cli.md)
+* [Using Bitmark shares](using-bitmark-shares.md)

--- a/pages/learning-bitmark/quick-start/README.md
+++ b/pages/learning-bitmark/quick-start/README.md
@@ -13,9 +13,9 @@
 
 ## [Working with bitmarks](working-with-bitmarks/README.md#working-with-bitmarks)
 
-* [Working with Bitmark](working-with-bitmark.md)
-* [Using the Bitmark app](using-bitmark-app.md)
-* [Using the SDK](using-sdk.md)
-* [Using the CLI](using-cli.md)
-* [CLI Payment](payment-for-bitmark-cli.md)
-* [Using Bitmark shares](using-bitmark-shares.md)
+* [Working with Bitmark](working-with-bitmarks/working-with-bitmark.md)
+* [Using the Bitmark app](working-with-bitmarks/using-bitmark-app.md)
+* [Using the SDK](working-with-bitmarks/using-sdk.md)
+* [Using the CLI](working-with-bitmarks/using-cli.md)
+* [CLI Payment](working-with-bitmarks/payment-for-bitmark-cli.md)
+* [Using Bitmark shares](working-with-bitmarks/using-bitmark-shares.md)

--- a/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md
+++ b/pages/learning-bitmark/quick-start/simple-solution-for-node-setup.md
@@ -3,7 +3,7 @@ title: Running a Bitmark Node
 keywords: node setup
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/simple-solution-for-node-setup
+permalink: /learning-bitmark/quick-start/running-a-bitmark-node
 folder: learning-bitmark/quick-start
 ---
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/README.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/README.md
@@ -12,35 +12,54 @@ Most work with the Bitmark Property System can be done via one of three methods:
 
 These documents detail the usage of each of these methods. 
 
-## [Creating Bitmark Accounts](creating-bitmark-account.md#creating-bitmark-account)
+## [Working with Bitmark](working-with-bitmark.md)
+
+* [Bitmark Account](working-with-bitmark.md#bitmark-account)
+  * [Bitmark Account Number](working-with-bitmark.md#bitmark-account-number)
+* [Bitmark Certificates](working-with-bitmark.md#bitmark-certificates)
+* [Transactions](working-with-bitmark.md#transactions)
+  * [Bitmark Certificate registration](working-with-bitmark.md#bitmark-certificate-registration)
+  * [Bitmark Certificate transfer](working-with-bitmark.md#bitmark-cetificate-transfer)
+* [Bitmark shares](working-with-bitmark.md#bitmark-shares)
+
+## [Using the Bitmark app](using-bitmark-app.md)
+
+* [Creating a Bitmark Account](using-bitmark-app.md#creating-a-bitmark-bccount)
+* [Registering Bitmark Certificates](using-bitmark-app.md#registering-bitmark-certificates)
+* [Transferring Bitmark Certificates](using-bitmark-app.md#transferring-bitmark-certificates)
+* [Exploring bitmark transactions using the Bitmark Registry website](using-bitmark-app.md#exploring-bitmark-transactions-using-the-bitmark-registry-website)
+
+## [Using the SDK](using-sdk.md)
+
+* [Initializing the JS SDK](using-sdk.md#initializing-the-js-sdk)
+* [Creating a Bitmark Account](using-sdk.md#creating-a-bitmark-bccount)
+* [Registering Bitmark Certificates](using-sdk.md#registering-bitmark-certificates)
+* [Transferring Bitmark Certificates](using-sdk.md#transferring-bitmark-certificates)
+* [Exploring bitmark transactions using the Bitmark Registry website](using-sdk.md#exploring-bitmark-transactions-using-the-bitmark-registry-website)
+
+## [Using the CLI](using-cli.md)
+
+* [The Basics of CLI commands](using-cli.md#the-basic-of-cli-commands)
+* [Prerequisites](using-cli.md#prerequisites)
+* [Creating a Bitmark Account](using-cli.md#creating-a-bitmark-bccount)
+* [Registering Bitmark Certificates](using-cli.md#registering-bitmark-certificates)
+* [Transferring Bitmark Certificates](using-cli.md#transferring-bitmark-certificates)
+* [Exploring bitmark transactions using the Bitmark Registry website](using-cli.md#exploring-bitmark-transactions-using-the-bitmark-registry-website)
+
+## [CLI Payment](payment-for-bitmark-cli.md)
+
+* [About the Bitmark Wallet](payment-for-bitmark-cli.md#about-the-bitmark-wallet)
+* [Prerequisites](payment-for-bitmark-cli.md#prerequisites)
+* [Using the Bitmark Wallet](payment-for-bitmark-cli.md#using-the-bitmark-wallet)
+  * [Installing the Bitmark Wallet](payment-for-bitmark-cli.md#installing-the-bitmark-wallet)
+  * [Connecting the Bitmark Wallet](payment-for-bitmark-cli.md#connecting-the-bitmark-wallet)
+  * [Running the Bitmark Wallet](payment-for-bitmark-cli.md#running-the-bitmark-wallet)
+  * [Getting testnet coins](payment-for-bitmark-cli.md#getting-testnet-coins)
+* [Paying for the Transaction](payment-for-bitmark-cli.md#paying-for-the-transaction)
+
+## [Using Bitmark shares](using-bitmark-shares.md)
   
-* [About the Bitmark Account Number](creating-bitmark-account.md#about-the-bitmark-account-number)
-* [Creating a Bitmark Account using the Bitmark App](creating-bitmark-account.md#creating-a-bitmark-account-using-the-bitmark-app)
-* [Creating a Bitmark Account using the Bitmark SDK](creating-bitmark-account.md#creating-a-bitmark-account-using-the-bitmark-sdk)
-* [Creating a Bitmark Account using the Bitmark-CLI](creating-bitmark-account.md#creating-a-bitmark-account-using-the-bitmark-cli)
-
-
-## [Registering Bitmark Certificates](issuing-bitmarks.md#registering-bitmark-certificates)
-  
-* [Prerequisites](issuing-bitmarks.md#prerequisites)
-* [Registering Bitmark Certificates using the Bitmark App](issuing-bitmarks.md#registering-bitmark-certificates-using-the-bitmark-app)
-* [Registering Bitmark Certificates using the Bitmark SDK](issuing-bitmarks.md#registering-bitmark-certificates-using-the-bitmark-sdk)
-* [Registering Bitmark Certificates using the Bitmark CLI](issuing-bitmarks.md#registering-bitmark-certificates-using-the-bitmark-cli)
-* [Exploring Bitmark transactions using the Bitmark Registry website](issuing-bitmarks.md#exploring-bitmark-transactions-using-the-bitmark-registry-website)
-
-
-## [Transferring Bitmark Certificates](transferring-bitmarks.md#transferring-bitmark-certificates)
-  
-* [Prerequisites](transferring-bitmarks.md#prerequisites)
-* [Transferring bitmarks using the Bitmark App](transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-app)
-* [Transferring bitmarks using the Bitmark SDK](transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-sdk)
-* [Transferring bitmarks using the Bitmark CLI](transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-cli)
-* [Exploring Bitmark transactions using the Bitmark Registry website](transferring-bitmarks.md#exploring-bitmark-transactions-using-the-bitmark-registry-website)
-
-
-## [Working with Bitmark Shares](using-bitmark-shares.md#bitmark-shares)
-  
-* [About Bitmark shares records](using-bitmark-shares.md#about-bitmark-shares-records)
+* [The Basics of CLI commands](using-bitmark-shares.md#the-basic-of-cli-commands)
 * [Prerequisites](using-bitmark-shares.md#prerequisites)
 * [Creating Bitmark shares](using-bitmark-shares.md#creating-bitmark-shares)
   * [Creating Bitmark shares from a Bitmark Certificate](using-bitmark-shares.md#creating-bitmark-shares-from-a-bitmark-certificate)
@@ -57,15 +76,3 @@ These documents detail the usage of each of these methods.
   * [Countersigning a share swap](using-bitmark-shares.md#countersigning-a-share-swap)
   * [Paying for a share swap](using-bitmark-shares.md#paying-for-a-share-swap)
   * [Verifying a share swap](using-bitmark-shares.md#verifying-a-share-swap)
-
-
-## [Paying for Bitmark Transactions](payment-for-bitmark-cli.md)
-
-* [About the Bitmark Wallet](payment-for-bitmark-cli.md#about-the-bitmark-wallet)
-* [Prerequisites](payment-for-bitmark-cli.md#prerequisites)
-* [Using the Bitmark Wallet](payment-for-bitmark-cli.md#using-the-bitmark-wallet)
-  * [Installing the Bitmark Wallet](payment-for-bitmark-cli.md#installing-the-bitmark-wallet)
-  * [Connecting the Bitmark Wallet](payment-for-bitmark-cli.md#connecting-the-bitmark-wallet)
-  * [Running the Bitmark Wallet](payment-for-bitmark-cli.md#running-the-bitmark-wallet)
-  * [Getting testnet coins](payment-for-bitmark-cli.md#getting-testnet-coins)
-* [Paying for the Transaction](payment-for-bitmark-cli.md#paying-for-the-transaction)

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/general-concept.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/general-concept.md
@@ -1,0 +1,74 @@
+---
+title: General concepts
+keywords: bitmark, account, transaction
+last_updated: 
+sidebar: mydoc_sidebar
+permalink: /learning-bitmark/quick-start/working-with-bitmarks/general-concepts
+folder: learning-bitmark/quick-start/working-with-bitmarks
+---
+
+# General concepts
+
+## Bitmark Account
+
+Any user interacting with the Bitmark Property System requires a Bitmark Account. It can be created using the [Bitmark App](using-bitmark-app.md#creating-a-bitmark-account), the [SDK](using-sdk.md#creating-a-bitmark-account), or the [CLI](using-cli.md#creating-a-bitmark-account).
+
+After creating an Account, a user will often want to recover the seed (which is the private key that can be used to control the Account) and the recovery phrase (which is a set of 12 mnemonic words that can be used to regenerate the seed).
+
+### Bitmark Account Number
+
+Property owners in Bitmark system are identified by their Ed25519 public keys. These public keys are represented in the Bitmark Property System by Bitmark Account Numbers, which encode the Ed25519 key in based58 format.
+
+*Example — Bitmark Account Number on [Livenet](https://registry.bitmark.com/account/bqSUHTVRYnrUPBEU48riv9UwDmdRnHm9Mf9LWYuYEa7JKtqgKw):*
+>       `bqSUHTVRYnrUPBEU48riv9UwDmdRnHm9Mf9LWYuYEa7JKtqgKw`
+         
+       
+*Example — Bitmark Account Number on [Testnet](https://registry.test.bitmark.com/account/fABCJxXc8aYGoj1yLLXmsGdWEo1Y5cZE9Ko5DrHhy4HvgGYMAu/owned):*
+>       `fABCJxXc8aYGoj1yLLXmsGdWEo1Y5cZE9Ko5DrHhy4HvgGYMAu`
+
+## Bitmark Certificates
+
+Assets with titles that have been publicly recorded are [more valuable](../../problem-we-are-trying-to-solve.md) than those without. They are what grant basic rights, such as the ability to resell, rent, lend, and donate the property. The Bitmark blockchain allows individuals to access these rights for digital assets by registering their titles as Bitmark Certificates. This can be done using the [Bitmark App](using-bitmark-app.md#registering-bitmark-certificates), the [SDK](using-sdk.md#registering-bitmark-certificates), or the [CLI](using-cli.md#registering-bitmark-certificates).
+
+## Transactions
+
+### Bitmark Certificate registration
+
+The process of registering a Bitmark Certificate for a digital asset occurs in two steps:
+
+* Registering the asset: this creates an *Asset Record*, which is stored on the Bitmark blockchain.
+
+* Issuing bitmarks: this creates *Issue Records* linking to the corresponding asset record, which are also stored on the Bitmark blockchain.
+
+This process registers legal property rights on the public Bitmark blockchain for an individual's digital assets, including personal health and social data, creative works such as art, photography, and music, and other intellectual property. These legal rights determine who owns property and what can be done with it, whether the individual wants to keep it, sell it, or donate it.
+
+### Bitmark Certificate transfer
+
+Once an asset has been registered, the owner can trade it by creating a transfer record that points back to the original issue record (or to a previous transfer record) and that lists the new owner of the asset. Because the blockchain is ordered and because it's immutable, this creates a permanent chain of custody reaching back to the asset's origins.
+
+<div style="background-color: #efefef; text-align: center;">
+    <img src="/assets/images/TransferringBitmark_0.png" alt="Record chain" title="Record chain" style="padding: 20px" />
+</div>
+
+Bitmark owners can transfer their Bitmark Certificates to others using the [Bitmark App](using-bitmark-app.md#transferring-bitmark-certificates), the [SDK](using-sdk.md#transferring-bitmark-certificates), or the [CLI](using-cli.md#transferring-bitmark-certificates).
+
+### Bitmark shares
+
+In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](https://docs.bitmark.com/bitmark-appendix/bitmark-shares)**.
+
+Any owner of a Bitmark Certificate is able to:
+
+* [Create Bitmark shares](#creating-bitmark-shares) from that Bitmark Certificate.
+* [Grant Bitmark shares](#granting-bitmark-shares-to-another-account) to another account.
+* [Swap Bitmark shares](#swapping-bitmark-shares) with other accounts.
+
+Three records related to Bitmark shares are stored on the Bitmark blockchain.
+
+* *Balance Record* - created by a bitmark owner to permanently set the total number of a particular share for a Bitmark Certificate.
+* *Grant Record* - created by an owner to grant an amount of his share balance to another owner.
+* *Swap Record* - created by two owners to simultaenously swap their shares of different Bitmark Certificates.
+
+The transactions related to the Bitmark shares can be done using the CLI as described in [Using Bitmark shares](using-bitmark-shares.md) section.
+
+
+

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
@@ -292,5 +292,5 @@ To fund a mainnet wallet, you'll need to send coins to the BTC or LTC address, b
 
 ## Paying for the Transaction
 
-Once your Bitcoin Wallet is set up, it can be used to pay for transactions. Instructions and examples can be found in the sections on [Transferring Bitmarks](transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-cli), [Paying for a Share Creation](using-bitmark-shares.md#paying-for-a-share-creation), [Paying for a Share Grant](https://github.com/bitmark-inc/docs/blob/shannona-patch-working-with-bitmark/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md#paying-for-a-share-grant), and [Paying for a Share Swap](using-bitmark-shares.md#paying-for-a-share-swap).
+Once your Bitcoin Wallet is set up, it can be used to pay for transactions. Instructions and examples can be found in [Using the CLI](using-cli.md) and [Using Bitmark shares](using-bitmark-shares.md) sections.
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
@@ -3,7 +3,7 @@ title: CLI Payment
 keywords: transaction payment
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/cli-payment
+permalink: /learning-bitmark/quick-start/cli-payment
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/payment-for-bitmark-cli.md
@@ -1,13 +1,13 @@
 ---
-title: Bitmark CLI Payment
+title: CLI Payment
 keywords: transaction payment
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/bitmark-cli-payment
+permalink: /learning-bitmark/quick-start/working-with-bitmarks/cli-payment
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 
-# Paying for Bitmark Transactions
+# CLI payment
 
 Bitmark transaction fees for transfers and share-related transactions can be paid in either Bitcoin (BTC) or Litecoin (LTC) cryptocurrencies. 
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md
@@ -3,7 +3,7 @@ title: Using the Bitmark app
 keywords: bitmark, account, transaction
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/usinng-bitmark-app
+permalink: /learning-bitmark/quick-start/using-the-bitmark-app
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-app.md
@@ -1,0 +1,184 @@
+---
+title: Using the Bitmark app
+keywords: bitmark, account, transaction
+last_updated: 
+sidebar: mydoc_sidebar
+permalink: /learning-bitmark/quick-start/working-with-bitmarks/usinng-bitmark-app
+folder: learning-bitmark/quick-start/working-with-bitmarks
+---
+
+# Using the Bitmark app
+
+The [Bitmark app](https://apps.apple.com/us/app/bitmark/id1429427796) allows users to:
+
+* Create a Bitmark Account
+
+* Register any kind of digital asset
+
+* Send your registered property to other accounts
+
+## Creating a Bitmark Account
+
+To create a Bitmark Account using the Bitmark App:
+
+* Download and install the [Android](https://play.google.com/store/apps/details?id=com.bitmark.registry) or [iOS](https://apps.apple.com/us/app/bitmark-property-registry/id1429427796) Bitmark App
+
+* Open the App
+
+* Tap the **CREATE NEW ACCOUNT** option
+    
+    > While creating an account, users can enable Touch/Face ID and Notification options.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/CreateAccount_0.png" alt="Create New Account option" title="Create New Account option" width="250" style="padding: 20px" />
+        <img src="/assets/images/CreateAccount_1.png" alt="Touch/Face ID option" title="Touch/Face ID option" width="250" style="padding: 20px" /> 
+        <img src="/assets/images/CreateAccount_3.png" alt="Notification option" title="Notification option" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Look up the Account Number by accessing **ACCOUNT > SETTINGS**; record it
+
+    > The Bitmark App allows users to
+    >
+    > * **Copy** the Account Number to clipboard directly by tapping on it; or
+    > * **Display** the Account Number as a QR Code by tapping on the QR Code icon.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/AccountMenu.png" alt="Account Menu" title="Account Menu" width="250" style="padding: 20px" />
+        <img src="/assets/images/AccountSettings.png" alt="Account Settings" title="Account Settings" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Backup the Recovery Phrase by selecting **ACCOUNT > SETTINGS > WRITE DOWN RECOVERY PHRASE**
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/RecoveryPhrase_0.png" alt="Write down Recovery Phrase option" title="Write down Recovery Phrase option" width="250" style="padding: 20px" />
+        <img src="/assets/images/RecoveryPhrase_1.png" alt="Write down Recovery Phrase" title="Write down Recovery Phrase" width="250" style="padding: 20px" />
+        <img src="/assets/images/RecoveryPhrase_2.png" alt="Recovery Phrase" title="Recovery Phrase" width="250" style="padding: 20px" />
+    </div>
+
+<br>
+
+## Registering Bitmark Certificates
+
+To register a new property using the Bitmark App:
+
+* On the **PROPERTIES** screen tap **CREATE FIRST PROPERTY** or **+**
+
+    > This opens the **PROPERTIES > REGISTER** screen.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/RegisteringProperties_0.png" alt="Properties screen" title="Properties screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_1.png" alt="Properties Register screen" title="Properties Register screen" width="250" style="padding: 20px" />
+    </div>
+
+<br>
+
+* Tap **PHOTOS** or **FILES** to browse the desired asset on your mobile device
+
+    > You must grant permission for access to `Photos` and/or `Files`.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/RegisteringProperties_2.png" alt="Grant Permission popup" title="Grant Permission popup" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_3.png" alt="Open Photos action sheet" title="Open Photos action sheet" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_4.png" alt="PHOTOS browsed" title="PHOTOS browsed" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Fill in the required information
+
+    > As soon as the desired asset is selected, the App will compute the asset's fingerprint and open the **REGISTER PROPERTY RIGHTS** screen, which allows users to provide more detailed information about the asset.
+    >
+    >* Currently, the `PROPERTY NAME` and `NUMBER OF BITMARKS TO ISSUE` fields are mandatory.
+    >
+    >* For each `Asset`, a user can issue multiple Bitmark Certificates, with the number defined by  `number of bitmarks` in the **REGISTER PROPERTY RIGHTS** screen.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/RegisteringProperties_5.png" alt="Register Property Rights screen" title="Register Property Rights screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_6.PNG" alt="Fill in required information" title="Fill in required information" width="250" style="padding: 20px" />
+    </div>
+
+<br>
+
+* Tap **ISSUE** button
+
+    >As soon as **ISSUE** is tapped, the App submits both the `Asset Registration` and `bitmarks Issuance` transactions to the Bitmark network. After the submission is successful, the properties will be added to the **PROPERTIES > YOURS** screen.
+    >
+    > **NOTE:** It will take a while for the transactions to be confirmed on the Bitmark blockchain after submission.
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/RegisteringProperties_7.png" alt="Submitting transaction" title="Submitting transactions" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_8.png" alt="Submission succeeded" title="Submission succeeded" width="250" style="padding: 20px" />
+        <img src="/assets/images/RegisteringProperties_9.PNG" alt="Properties added" title="Properties added" width="250" style="padding: 20px" />
+    </div>
+
+<br>
+
+## Transferring Bitmark Certificates
+
+To transfer a Bitmark Certificate using the Bitmark App:
+
+* On the **PROPERTIES > YOURS** screen, tap on the desired property to open the **PROPERTY DETAILS** screen
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_1.png" alt="Properties screen" title="Properties screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/TransferBitmark_2.png" alt="Property Details screen" title="Property Details screen" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Tap on the `...` at the top right corner to open the options and select the **TRANSFER** option
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_3.png" alt="Property options" title="Property options" width="250" style="padding: 20px" />
+        <img src="/assets/images/TransferBitmark_4.png" alt="Bitmark Transfer screen" title="Bitmark Transfer screen" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Fill in the recipient account and tap **TRANSFER**
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_5.png" alt="Enter Account screen" title="Enter Account screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/TransferBitmark_6.png" alt="Transferring screen" title="Transferring screen" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Observe changes on the sender side: the property disappears
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_7.png" alt="Transferred" title="Transferred" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Observe changes on the recipient side right after the transfer
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_8.png" alt="Recipient Properties screen" title="Recipient Properties screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/TransferBitmark_9.png" alt=" Recipient Properties Details screen" title="Recipient Properties Details screen" width="250" style="padding: 20px" />
+    </div>
+
+    <br>
+
+* Observe changes on the recipient side after some minutes
+
+    <div style="background-color: #efefef; text-align: center;">
+        <img src="/assets/images/TransferBitmark_10.png" alt="Confirmed Properties screen" title="Confirmed Properties screen" width="250" style="padding: 20px" />
+        <img src="/assets/images/TransferBitmark_11.png" alt="Confirmed Details screen" title="Confirmed Details screen" width="250" style="padding: 20px" />
+    </div>
+
+<br>
+
+## Exploring bitmark transactions using the Bitmark Registry website
+
+Userse can explore all of the transactions on the Bitmark blockchain using the Bitmark Registry web application:
+
+* For transactions on the Bitmark livenet blockchain: https://registry.bitmark.com
+
+* For transactions on the Bitmark testnet blockchain: https://registry.test.bitmark.com
+

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
@@ -7,37 +7,32 @@ permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-sha
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 
-# Working with Bitmark shares
+# Using Bitmark shares
 
-In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](https://docs.bitmark.com/bitmark-appendix/bitmark-shares)**.
-
-Any owner of a Bitmark Certificate is able to:
-
-* [Create Bitmark shares](#creating-bitmark-shares) from that Bitmark Certificate.
-* [Grant Bitmark shares](#granting-bitmark-shares-to-another-account) to another account.
-* [Swap Bitmark shares](#swapping-bitmark-shares) with other accounts.
-
-
-Currently, only the Bitmark-CLI supports working with bitmark shares.
+Currently, only the Bitmark CLI supports working with bitmark shares.
 
 > **NOTE:** Transactions related to Bitmark shares require a transaction fee. On the bitmark network, the fee can be paid with BTC or LTC
 >
 > * Real BTC and/or LTC are used to pay for transaction fee on the Bitmark main chain
 > * Testnet BTC and/or LTC are used to pay for transaction fee on the Bitmark testing chain
 
-### About Bitmark shares records
+## The Basics of CLI commands
 
-Three records related to Bitmark shares are stored on the Bitmark blockchain.
+All Bitmark-CLI commands follow the same basic structure:
 
-* *Balance Record* - created by a bitmark owner to permanently set the total number of a particular share for a Bitmark Certificate.
-* *Grant Record* - created by an owner to grant an amount of his share balance to another owner.
-* *Swap Record* - created by two owners to simultaenously swap their shares of different Bitmark Certificates.
+`$ bitmark-cli [global-options] command [command-options]`
+    
+You will need to send the Bitmark-CLI the global option `--network` (abbreviation: `-n`) to identify the network that you are sending the command to.
+
+**Network Options:**
+* `bitmark`:  the live network, which uses live BTC or LTC to pay for the transactions.
+* `testing`:  a network for testing newly developed programs, which uses testnet coins to pay for transactions.
+* `local`: a special case for running a regression test network on the loopback interface.
 
 ## Prerequisites
 
-The `bitmark-wallet` software is required for paying for transactions. Please refer to the [Payment on Bitmark CLI](payment-for-bitmark-cli.md) document for instructions on installing it.
+The `bitmark-wallet` software is required for paying for transactions. Please refer to the [CLI payment](payment-for-bitmark-cli.md) document for instructions on installing it.
 
-See [The Basics of Bitmark-CLI](https://github.com/bitmark-inc/docs/blob/shannona-patch-working-with-bitmark/learning-bitmark/quick-start/working-with-bitmarks/creating-bitmark-account.md#creating-a-bitmark-account-using-the-bitmark-cli) for more information on the interface.
 
 ## Creating Bitmark shares
 
@@ -508,7 +503,7 @@ To initialize a swap of shares using the Bitcoin-CLI:
     }
   ```
 
-#### Countersigning a share swap
+### Countersigning a share swap
 
 A share-swap transaction requires two signatures. The sender signs when running the `swap` command, after which the receiver must countersign. This process is the same as when countersigning a `grant` transaction.
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
@@ -3,7 +3,7 @@ title: Using Bitmark Shares
 keywords: bitmark shares
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares
+permalink: /learning-bitmark/quick-start/using-bitmark-shares
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
@@ -108,7 +108,7 @@ To create Bitmark shares using the Bitmark-CLI:
 
 ### Paying for a share creation
 
-Paying for Bitmark share creation works the same way as [paying for a Bitmark Certificate transfer](/pages/learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-cli).
+Paying for Bitmark share creation works the same way as [paying for a Bitmark Certificate transfer](using-cli.md#transferring-bitmarks-using-the-bitmark-cli).
 
 To do so using the Bitmark-CLI:
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares.md
@@ -108,7 +108,7 @@ To create Bitmark shares using the Bitmark-CLI:
 
 ### Paying for a share creation
 
-Paying for Bitmark share creation works the same way as [paying for a Bitmark Certificate transfer](https://github.com/bitmark-inc/docs/blob/shannona-patch-working-with-bitmark/learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-cli).
+Paying for Bitmark share creation works the same way as [paying for a Bitmark Certificate transfer](/pages/learning-bitmark/quick-start/working-with-bitmarks/transferring-bitmarks.md#transferring-bitmarks-using-the-bitmark-cli).
 
 To do so using the Bitmark-CLI:
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
@@ -9,7 +9,7 @@ folder: learning-bitmark/quick-start/working-with-bitmarks
 
 # Using the CLI
 
-This section introduces simple commands to create a new Bitmark Account, execute some simple transactions using the Bitmark-CLI. For the command structures, detailed explanations, and other functions please refer the [Bitmark-CLI](https://github.com/bitmark-inc/docs/blob/master/bitmark-references/bitmark-cli/bitmark-cli.md) documents.
+This section introduces simple commands to create a new Bitmark Account, execute some simple transactions using the Bitmark-CLI. For the command structures, detailed explanations, and other functions please refer the [Bitmark-CLI](/pages/bitmark-references/bitmark-cli/bitmark-cli.md) documents.
 
 ## The Basics of CLI commands
 
@@ -32,7 +32,7 @@ The `bitmark-wallet` software is required for paying for transactions. Please re
 
 To create a Bitmark Account using the BitmarkCLI:
 
-* Install [Bitmark-CLI](https://github.com/bitmark-inc/docs/blob/master/bitmark-references/bitmark-cli/bitmark-cli.md)
+* Install [Bitmark-CLI](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
 
 * Initialize the Bitmark-CLI configuration
 
@@ -449,10 +449,6 @@ To transfer a Bitmark Certificate using the Bitmark-CLI:
           "_IDENTITY": "first"
     }
     ```
-
-## Working with bitmark shares
-
-Refer [Working with Bitmark shares](https://docs.bitmark.com/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares) section. 
 
 ## Exploring Bitmark transactions using the Bitmark Registry website
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
@@ -9,7 +9,7 @@ folder: learning-bitmark/quick-start/working-with-bitmarks
 
 # Using the CLI
 
-This section introduces simple commands to create a new Bitmark Account, execute some simple transactions using the Bitmark-CLI. For the command structures, detailed explanations, and other functions please refer the [Bitmark-CLI](/pages/bitmark-references/bitmark-cli/bitmark-cli.md) documents.
+This section introduces simple commands to create a new Bitmark Account, execute some simple transactions using the Bitmark-CLI. For the command structures, detailed explanations, and other functions please refer the [Bitmark-CLI](../../../bitmark-references/bitmark-cli/bitmark-cli.md) documents.
 
 ## The Basics of CLI commands
 
@@ -32,7 +32,7 @@ The `bitmark-wallet` software is required for paying for transactions. Please re
 
 To create a Bitmark Account using the BitmarkCLI:
 
-* Install [Bitmark-CLI](/pages/bitmark-references/bitmark-cli/bitmark-cli.md)
+* Install [Bitmark-CLI](../../../bitmark-references/bitmark-cli/bitmark-cli.md)
 
 * Initialize the Bitmark-CLI configuration
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
@@ -3,7 +3,7 @@ title: Using the CLI
 keywords: bitmark, account, transaction
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-sdk
+permalink: /learning-bitmark/quick-start/using-the-cli
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-cli.md
@@ -1,0 +1,463 @@
+---
+title: Using the CLI
+keywords: bitmark, account, transaction
+last_updated: 
+sidebar: mydoc_sidebar
+permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-sdk
+folder: learning-bitmark/quick-start/working-with-bitmarks
+---
+
+# Using the CLI
+
+This section introduces simple commands to create a new Bitmark Account, execute some simple transactions using the Bitmark-CLI. For the command structures, detailed explanations, and other functions please refer the [Bitmark-CLI](https://github.com/bitmark-inc/docs/blob/master/bitmark-references/bitmark-cli/bitmark-cli.md) documents.
+
+## The Basics of CLI commands
+
+All Bitmark-CLI commands follow the same basic structure:
+
+`$ bitmark-cli [global-options] command [command-options]`
+    
+You will need to send the Bitmark-CLI the global option `--network` (abbreviation: `-n`) to identify the network that you are sending the command to.
+
+**Network Options:**
+* `bitmark`:  the live network, which uses live BTC or LTC to pay for the transactions.
+* `testing`:  a network for testing newly developed programs, which uses testnet coins to pay for transactions.
+* `local`: a special case for running a regression test network on the loopback interface.
+
+## Prerequisites
+
+The `bitmark-wallet` software is required for paying for transactions. Please refer to the [CLI payment](payment-for-bitmark-cli.md) document for instructions on installing it.
+
+## Creating a Bitmark Account
+
+To create a Bitmark Account using the BitmarkCLI:
+
+* Install [Bitmark-CLI](https://github.com/bitmark-inc/docs/blob/master/bitmark-references/bitmark-cli/bitmark-cli.md)
+
+* Initialize the Bitmark-CLI configuration
+
+    ```shell
+    $ bitmark-cli -n <network> -i <identity> \
+    setup -c <node>:2130 -d '<description>' -n
+    ```
+
+    >The `setup` command initializes the Bitmark-CLI config file.
+    >
+    > **Global Options:**
+    >* `network` - The network to which the command is sent.
+    >* `identity` - The identity of the Bitmark-CLI user.
+    >
+    > **Command Options:**
+    >* `node` - The Bitmark node to which the Bitmark-CLI connects and submits its transactions.
+    >* `description` - The identity’s description. 
+    >* `-n` (abbr. of --new) - A new account is being created.
+    
+    *Example:*
+ 
+    ```shell
+    $ bitmark-cli -n testing -i first \
+    setup -c 128.199.89.154:2130 -d 'first user' -n
+    ```
+    > This command creates a user on the testing network using the node 128.199.89.154:2130 with the user having an identity of "first" and a description of "first user".
+
+*  Add an additional Bitmark account
+    ```shell
+    $ bitmark-cli -n <network> -i <identity> \
+    add -d '<description>' -n
+    ```
+    > The `add` command adds a new user after the Bitmark-CLI configuration was initialized. 
+    > The command options have the same meanings as in the `setup` command.
+    
+    *Example:*  
+    ```shell
+    $ bitmark-cli -n testing -i second \
+    add -d 'second user' -n
+    ```
+
+* Check the account numbers
+    ```shell
+    $ bitmark-cli -n <network> list
+    ```
+
+    > The `list` command lists all the users of the Bitmark-CLI.
+    
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing list
+    ```
+    ```
+    SK first    fUuNhZ6CC4YxUkQB99nuLnUiEevEuwdCoYszJ9Y5uUjp8oiA3A  "first user"
+    SK second   fPWWkW45o12er6oP4EveaURHXstkSXR3odWCgpaDvEvxoR3woC  "second user"
+    ```
+
+
+* Get the account seed and recovery phrase for an identity
+    ```shell
+    $ bitmark-cli -n <network> -i <identity> seed
+    ```
+
+    > The `seed` command prints out all the information about a Bitmark-CLI user. 
+    
+    *Example:*
+ 
+    ```shell
+    $ bitmark-cli -n testing -i first seed
+    ```
+    ```json
+    {
+        "privateKey": "BQVdbCAVQ1KHv4sDSQ5d874BfZYmLeeJveNGXThxU4WKh5K39o6eEVqoBZFKbJWHiJgkyYThnBFdfF9bgSGmhyDLsk7oR9",
+        "seed": "9J87ApGrXzDitFk8eviHf31RNXbTcjW8S",
+        "description": "first user",
+        "name": "first",
+        "account": "fUuNhZ6CC4YxUkQB99nuLnUiEevEuwdCoYszJ9Y5uUjp8oiA3A",
+        "recovery_phrase": "lamp between sponsor butter lawn ski venture autumn anger corn bullet catalog"
+    }
+    ```
+
+**NOTE:** 
+
+* The account creation commands require users to provide and confirm a password.
+* All identity-required commands ask for the account password. For example, the `seed` command requires it because it outputs sensitive data.
+
+## Registering Bitmark Certificates
+
+To register a new property using the Bitmark-CLI:
+
+* Compute the hash of an asset
+
+    ```shell
+    $ bitmark-cli -n <network> \
+    fingerprint -f <file>
+    ```
+
+    > The `fingerprint` command computes the hash of a file
+    >
+    > **Command Options:**
+    > * `file` - The file from which the hash is computed.
+
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing \
+    fingerprint -f test.txt
+    ```
+    ```json
+    {
+        "file_name": "filename.test",
+        "fingerprint": "0122aa7d05ce9d324feca37780eeeeb7af8611eefb61cfe42bf9f8127071b481520b529e06c9f0799c7527859361f1694acef106d5131a96641eae524e1c323500"
+    }
+    ```
+
+* Issue the first Bitmark Certificate
+
+    ```shell
+    $ bitmark-cli -n <network> -i <identity> \
+    create -a '<asset name>' \
+    -m '<asset metadata>' \
+    -f <asset fingerprint> \
+    -z
+    ```
+
+    > The `create` command registers an asset from a fingerprint *and* issues the corresponding bitmarks
+    >
+    > **Global Options:**
+    >* `identity` - The identity of the registrant's Bitmark Account, which is stored in the Bitmark-CLI config file. 
+    >
+    > **Command Options:**
+    >* `asset name` - The `name` field in the asset record.
+    >
+    >* `asset metadata` - The `metadata` field in the asset record.
+    >
+    >* `asset fingerprint` - The hash of the asset.
+    >
+    >* `-z` option - This is the first Bitmark issued for the asset.
+
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing -i first \
+    create -a 'Example asset' \
+    -m 'Key1\u0000Value1\u0000Key2\u0000Value2' \
+    -f 0122aa7d05ce9d324feca37780eeeeb7af8611eefb61cfe42bf9f8127071b481520b529e06c9f0799c7527859361f1694acef106d5131a96641eae524e1c323500 \
+    -z
+    ```
+    ```json
+    {
+        "assetId": "dac17bef505f7a5acf890a1d0f232b7d847f1e951cf1f5b880de13253a10df43cdbcab553e08050808e0b3fdfd2581a798dcdf9cedbbddf4476ead14caa612d3",
+        "issueIds": [
+            "b069f2956b828281dec040782eea3d63793ab4cf17c26f7639e95f6f3b20ba23"
+        ],
+        "payId": "b30bf53de9f6ae5ca59259fd695566bce692d422201c222ff136ab3193f16301e055b1030ce46a1981f439105b3a96e2",
+        "payNonce": "a7b23fc462594028",
+        "difficulty": "0000ffffffffffffff8000000000000000000000000000000000000000000000",
+        "submittedNonce": "00000001a67fa973",
+        "proofStatus": "Accepted"
+    }
+    ```
+
+* Verify the status of the Bitmark issuance transaction
+
+    ```shell
+    $ bitmark-cli -n <network>\
+      status -t <txid>
+    ```
+
+    > The `status` commands checks if a Bitmark has been issued
+    >
+    >**Command Options:**
+    >* `txid` — The transaction being verified, corresponding to the `issueIds` from the `create` command
+    >
+    >**Returns:**
+    >* `Pending` - Not paid.
+    >
+    >* `Verified` - Paid but not confirmed on the blockchain.
+    >
+    >* `Confirmed` - Confirmed on the blockchain.
+    
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing \
+      status -t \
+      b069f2956b828281dec040782eea3d63793ab4cf17c26f7639e95f6f3b20ba23
+    ```
+
+    ```json
+    // Check right after the create command
+    {
+      "status": "Pending"
+    }
+
+    // Check again after some minutes
+    {
+      "status": "Confirmed"
+    }
+    ```
+
+## Transferring bitmarks using the Bitmark-CLI
+
+The Bitmark-CLI allows users to transfer bitmarks by submitting the transactions to its connected node and then broadcasting to the network.
+
+To transfer a Bitmark Certificate using the Bitmark-CLI:
+
+* Submit a transfer request
+
+    ```shell
+    $ bitmark-cli -n <network> -i <sender identity>\
+      transfer -r <receiver> \
+      -t <txid> -u
+    ```
+    
+    > The `transfer` command submits a transfer transaction to the network. 
+    >
+    > **Global Options:**
+    >* `sender identity` - The identity of the sender's Bitmark Account, which is stored in the Bitmark-CLI config file
+    >
+    > **Command Options:**
+    >* `receiver` - The identifier of the recipient's Bitmark Account. This can be a Bitmark Account Number or the Bitmark Account's identity, if it's stored in the Bitmark-CLI config file
+    >
+    > `txid` - The id of the last transaction of the Bitmark that is being transferring.
+    >
+    >**NOTE:** A transfer transaction on the Bitmark blockchain requires a transaction fee of 0.0002 BTC (20000 satoshis) or 0.002 LTC (200000 photons). Therefore, after the `transfer` command, the user will need to execute the payment on the Bitcoin or Litecoin blockchain. This payment information is included in the output of the `transfer` command.
+    >
+    > The transfer command also auto generates the `bitmark-wallet` commands for paying for the transaction and displays them at the end of the output.
+
+
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing -i first\
+      transfer -r second \
+      -t 6b35dfb5d623f6cae22fd03b3e28f1fde5255a29c1328a5d39ddfdfcd0ce6cf9 -u
+    ```
+    ```json
+    {
+      "transferId": "4656604222152d08606d42a40c8590c2100c177cafe374ea90bae30c5bd371e0",
+      "bitmarkId": "7e3337ae7596864e6dfd918c07780480ef80cea96fa039ed17d35c3849fcb3ca",
+      "payId": "d819cff364b9211093fe09c2b462bdd05154472a72fac91a882a8f1129674dc92ac5d2724c8d26b16d414de8fbc5c62e",
+      "payments": {
+        "BTC": [
+          {
+            "currency": "BTC",
+            "address": "mr8DEygRvQwKfP4sVZuHVozqvzW89e193j",
+            "amount": "20000"
+          }
+        ],
+        "LTC": [
+          {
+            "currency": "LTC",
+            "address": "mzkCaHJmu1gdnsL9jxW2bwqtw2MCCy66Ds",
+            "amount": "200000"
+          }
+        ]
+      }
+    },
+    "commands": {
+      "BTC": "bitmark-wallet --conf ${XDG_CONFIG_HOME}/bitmark-wallet/test/test-bitmark-wallet.conf btc --testnet sendmany --hex-data 'd819cff364b9211093fe09c2b462bdd05154472a72fac91a882a8f1129674dc92ac5d2724c8d26b16d414de8fbc5c62e' 'mnTuuYNZmmswFT8iqr7ex82HAQYLJ8LXkC,10000' 'mr8DEygRvQwKfP4sVZuHVozqvzW89e193j,20000'",
+      "LTC": "bitmark-wallet --conf ${XDG_CONFIG_HOME}/bitmark-wallet/test/test-bitmark-wallet.conf ltc --testnet sendmany --hex-data 'd819cff364b9211093fe09c2b462bdd05154472a72fac91a882a8f1129674dc92ac5d2724c8d26b16d414de8fbc5c62e' 'mzkCaHJmu1gdnsL9jxW2bwqtw2MCCy66Ds,200000'"
+    }
+    ```
+
+
+* Pay for the bitmark transfer using `bitmark-wallet`
+
+    ```shell
+    #Run the bitcoind
+    $ bitcoind -datadir=<bitcoind config dir>
+
+    # OR run the litecoind
+    $ litecoind -datadir=<litcoind config dir>
+
+    #Pay by BTC
+    $ bitmark-wallet --conf <Bitmark-Wallet config file> btc --<btc network> \
+      sendmany --hex-data '<payId>' '<btc address>,<btc amount in satoshi>'
+
+    #OR Pay by LTC
+    $ bitmark-wallet --conf <Bitmark-Wallet config file> ltc --<ltc network> \
+      sendmany --hex-data '<payId>' '<ltc address>,<ltc amount in photon>'
+
+    ```
+
+    >To execute a bitcoin or litecoin transaction on the local environment, the `bitcoind` or `litecoind` daemon must be running.
+    >
+    > - `payId` - The payment id for the transfer transaction, printed in the results as `payId`
+    > - `btc address` or `ltc address` - The address for payment, printed in the results as `address` under `BTC` or `LTC`
+    > - `btc amount` or `ltc amount` - The payment amount, printed in the results as `amount` under `BTC` or `LTC`
+
+    *Example — Paying by LTC:*
+
+    ```shell
+    # run litecoind
+    $ litecoind -datadir=~/.config/litecoin/
+
+    # Perform payment
+    $ bitmark-wallet --conf ~/.config/bitmark-wallet/test/test-bitmark-wallet.conf \
+      ltc --testnet \
+      sendmany --hex-data \
+      'd819cff364b9211093fe09c2b462bdd05154472a72fac91a882a8f1129674dc92ac5d2724c8d26b16d414de8fbc5c62e' \
+      'mzkCaHJmu1gdnsL9jxW2bwqtw2MCCy66Ds,200000'
+    ```
+    ```json
+    {
+      "txId": "ca94ae188ba8bfdc42e026950c5e13a2f1082dae484a45c5dc29217ac0c9a23f",
+      "rawTx": "0100000001b76a37054a086c5bd68afd61914bb4badc78c9e7ef59e6b692777cc18063632d020000006b483045022100db6f27ec3e1e59c34887f262217d5ff819947c561f0ecd11034ba8b32dbdc87002203ef82d80be8e43434eb16e22248e4533a1d3c2831e19802ce55a308604d76f3c012103b45a55c3e48209581d63ba5ceea9a0e94ae49e18056d85a6dadec535dbe237a2ffffffff03400d0300000000001976a914d2ebb7b259fb7410dca19b707c4091195d818ac488ac8091e305000000001976a9142d477753d17099534f9249b54cda36081d4e5eba88ac0000000000000000326a30d819cff364b9211093fe09c2b462bdd05154472a72fac91a882a8f1129674dc92ac5d2724c8d26b16d414de8fbc5c62e00000000"
+    }
+    ```
+
+* Verify the status of the transfer transaction
+
+    ```shell
+    $ bitmark-cli -n <network> \
+      status -t <transferId>
+    ```
+
+    >The `status` command queries a transaction's status.
+    >
+    >**Command Options:**
+    >* `transferId` - The transfer transaction id, printed as `transferId` in the output of the `transfer` command.
+    >
+    >**Returns:**
+    >* `Pending` - Not paid.
+    >
+    >* `Verified` - Paid but not confirmed on the blockchain.
+    >
+    >* `Confirmed` - Confirmed on the blockchain.
+
+
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing \
+      status -t \
+      4656604222152d08606d42a40c8590c2100c177cafe374ea90bae30c5bd371e0
+    ```
+    ```json
+    //Right after the payment
+    {
+      "status": "Verified"
+    }
+
+    //Check again fter some minutes
+    {
+      "status": "Confirmed"
+    }
+    ```
+
+    <br>
+
+* Verify the Bitmark's provenance
+
+    ```shell
+    $ bitmark-cli -n <network> \
+      provenance -t <transferID>
+    ```
+
+    >The `provenance` command returns all the transaction records related to an asset from the transaction corresponding to the txid back to the Bitmark's asset registration record. 
+    >
+    > **Command options:**
+    >* `transferID` - `transferId` - The transfer transaction id, printed as `transferId` in the output of the `transfer` command
+
+    *Example:*
+
+    ```shell
+    $ bitmark-cli -n testing \
+      provenance -t \
+      4656604222152d08606d42a40c8590c2100c177cafe374ea90bae30c5bd371e0
+    ```
+    ```json
+    {
+      "data": [
+        {
+          "record": "BitmarkTransferUnratified",
+          "isOwner": true,
+          "txId": "4656604222152d08606d42a40c8590c2100c177cafe374ea90bae30c5bd371e0",
+          "inBlock": 31101,
+          "data": {
+            "escrow": null,
+            "link": "7e3337ae7596864e6dfd918c07780480ef80cea96fa039ed17d35c3849fcb3ca",
+            "owner": "fPWWkW45o12er6oP4EveaURHXstkSXR3odWCgpaDvEvxoR3woC",
+            "signature": "1d378c7e...7dafcc02"
+          },
+          "_IDENTITY": "second"
+        },
+        {
+          "record": "BitmarkIssue",
+          "isOwner": false,
+          "txId": "7e3337ae7596864e6dfd918c07780480ef80cea96fa039ed17d35c3849fcb3ca",
+          "inBlock": 31100,
+          "data": {
+            "assetId": "813b2eb5...de9219a7",
+            "nonce": 0,
+            "owner": "fUuNhZ6CC4YxUkQB99nuLnUiEevEuwdCoYszJ9Y5uUjp8oiA3A",
+            "signature": "4581ee97...9b24f20f"
+          },
+          "_IDENTITY": "first"
+        },
+        {
+          "record": "AssetData",
+          "isOwner": false,
+          "inBlock": 31100,
+          "assetId": "813b2eb5...de9219a7",
+          "data": {
+            "fingerprint": "01cdb27c...50514f0c",
+            "metadata": "Key1\u0000Value1\u0000Key2\u0000Value2",
+            "name": "Example asset 3",
+            "registrant": "fUuNhZ6CC4YxUkQB99nuLnUiEevEuwdCoYszJ9Y5uUjp8oiA3A",
+            "signature": "d6cc18e5...47efe909"
+          },
+          "_IDENTITY": "first"
+    }
+    ```
+
+## Working with bitmark shares
+
+Refer [Working with Bitmark shares](https://docs.bitmark.com/learning-bitmark/quick-start/working-with-bitmarks/using-bitmark-shares) section. 
+
+## Exploring Bitmark transactions using the Bitmark Registry website
+
+Users can explore all of the transactions on the Bitmark blockchain using the Bitmark Registry web application:
+
+* For transactions on the Bitmark livenet blockchain: https://registry.bitmark.com
+
+* For transactions on the Bitmark testnet blockchain: https://registry.test.bitmark.com

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md
@@ -1,0 +1,132 @@
+---
+title: Using the SDK
+keywords: bitmark, account, transaction
+last_updated: 
+sidebar: mydoc_sidebar
+permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-sdk
+folder: learning-bitmark/quick-start/working-with-bitmarks
+---
+
+# Using the SDK
+
+This section introduces a simple way to create a new Bitmark Account and execute bitmark transactions using the JS SDK. For a detailed explanation, further functions, and other languages please consult the [Bitmark SDK](../../../../bitmark-references/bitmark-sdk/bitmark-sdk-document.md) documents.
+
+## Creating a Bitmark Account
+
+To initialize the Bitmark JS SDK, create a Bitmark Account, and export the related information:
+
+* Install the Bitmark JS SDK
+
+    `# npm install bitmark-sdk`
+
+* Initialize the SDK configuration
+
+    ```js
+        const sdk = require('bitmark-sdk');
+
+        const config = {
+            API_token: "api-token",
+            network: "testnet"
+        };
+
+        sdk.init(config);
+    ```
+
+    > The SDK supports two options for the network, each requiring a corresponding API tokens:
+    > 
+    > * "livenet" - all requests are submitted to the public Bitmark blockchain, which is the main chain. 
+    > 
+    > * "testnet" - all  requests are submitted to the testing Bitmark blockchain, which is normally used for testing and development activities.
+
+* Create a new Bitmark account
+
+    ```js
+    let account = new sdk.Account();
+    ```
+
+* Retrieve the Account number
+
+    ```js
+    let account_number = account.getAccountNumber();
+    ```
+
+* Retrieve the Account seed
+    ```js
+    let seed = account.getSeed();
+    ```
+* Retrieve the Account recovery phrase
+    ```js
+    let phrase = account.getRecoveryPhrase();
+    ```
+
+## Registering Bitmark Certificates
+
+To register a new property using the Bitmark JS SDK:
+
+* Register an asset
+
+    ```js
+    // Create a Bitmark Account as the Issuer
+    let account = new sdk.Account();
+
+    // Define the asset name & metadata
+    let name = "Example asset";
+    let metadata = {"Example key":"Example alue"};
+
+    // Build and sign the asset registration request
+    let params = sdk.Asset.newRegistrationParams(name, metadata);
+    await params.setFingerprint(filepath);
+    params.sign(account);
+
+    // Send the request
+    let assets = (await sdk.Asset.register(params)).assets;
+
+    let assetId = assets[0].id;
+    ```
+
+* Issue the first Bitmark Certificate
+
+    ```js
+    // Build and sign the bitmark issuance request
+    let issueParams = sdk.Bitmark.newIssuanceParams(assetId, 1);
+    issueParams.sign(account);
+
+    // Send the request
+    let bitmarks = (await sdk.Bitmark.issue(issueParams)).bitmarks;
+
+    let bitmarkId = bitmarks[0].id;
+    ```
+
+* Verify the issuance transaction by querying for the Bitmark by its `bitmarkId`
+
+    ```js
+        await Bitmark.get(bitmarkId);
+    ```
+## Transferring bitmarks using the Bitmark SDK
+
+To transfer a Bitmark Certificate using the Bitmark JS SDK:
+
+* Submit a transfer transaction
+
+    ```js
+        let transferParams = Bitmark.newTransferParams(recipientAccount);
+        await transferParams.fromBitmark(bitmarkid);
+        transferParams.sign(sender);
+
+        let txs = (await Bitmark.transfer(transferParams)).txs;
+        let txId = txs[0].id;
+    ```
+
+* Verify the transfer transaction
+
+    ```js
+        await Transaction.get(txId);
+    ```
+
+## Exploring bitmark transactions using the Bitmark Registry website
+
+Userse can explore all of the transactions on the Bitmark blockchain using the Bitmark Registry web application:
+
+* For transactions on the Bitmark livenet blockchain: https://registry.bitmark.com
+
+* For transactions on the Bitmark testnet blockchain: https://registry.test.bitmark.com

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/using-sdk.md
@@ -3,7 +3,7 @@ title: Using the SDK
 keywords: bitmark, account, transaction
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/using-sdk
+permalink: /learning-bitmark/quick-start/using-the-sdk
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 
@@ -11,11 +11,11 @@ folder: learning-bitmark/quick-start/working-with-bitmarks
 
 This section introduces a simple way to create a new Bitmark Account and execute bitmark transactions using the JS SDK. For a detailed explanation, further functions, and other languages please consult the [Bitmark SDK](../../../../bitmark-references/bitmark-sdk/bitmark-sdk-document.md) documents.
 
-## Creating a Bitmark Account
+## Initializing the JS SDK
 
-To initialize the Bitmark JS SDK, create a Bitmark Account, and export the related information:
+To initialize the JS SDK:
 
-* Install the Bitmark JS SDK
+* Install the JS SDK
 
     `# npm install bitmark-sdk`
 
@@ -37,6 +37,10 @@ To initialize the Bitmark JS SDK, create a Bitmark Account, and export the relat
     > * "livenet" - all requests are submitted to the public Bitmark blockchain, which is the main chain. 
     > 
     > * "testnet" - all  requests are submitted to the testing Bitmark blockchain, which is normally used for testing and development activities.
+
+## Creating a Bitmark Account
+
+To create a Bitmark Account, and export the related information:
 
 * Create a new Bitmark account
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
@@ -54,13 +54,13 @@ Bitmark owners can transfer their Bitmark Certificates to others using the [Bitm
 
 ## Bitmark shares
 
-In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](https://docs.bitmark.com/bitmark-appendix/bitmark-shares)**.
+In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](/pages/bitmark-appendix/bitmark-shares)**.
 
 Any owner of a Bitmark Certificate is able to:
 
-* [Create Bitmark shares](#creating-bitmark-shares) from that Bitmark Certificate.
-* [Grant Bitmark shares](#granting-bitmark-shares-to-another-account) to another account.
-* [Swap Bitmark shares](#swapping-bitmark-shares) with other accounts.
+* [Create Bitmark shares](using-bitmark-shares.md#creating-bitmark-shares) from that Bitmark Certificate.
+* [Grant Bitmark shares](using-bitmark-shares.md#granting-bitmark-shares-to-another-account) to another account.
+* [Swap Bitmark shares](using-bitmark-shares.md#swapping-bitmark-shares) with other accounts.
 
 Three records related to Bitmark shares are stored on the Bitmark blockchain.
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
@@ -54,7 +54,7 @@ Bitmark owners can transfer their Bitmark Certificates to others using the [Bitm
 
 ## Bitmark shares
 
-In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](/pages/bitmark-appendix/bitmark-shares)**.
+In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](../.../../bitmark-appendix/bitmark-shares)**.
 
 Any owner of a Bitmark Certificate is able to:
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
@@ -54,7 +54,7 @@ Bitmark owners can transfer their Bitmark Certificates to others using the [Bitm
 
 ## Bitmark shares
 
-In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](../.../../bitmark-appendix/bitmark-shares)**.
+In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](/pages/bitmark-appendix/bitmark-shares)**.
 
 Any owner of a Bitmark Certificate is able to:
 

--- a/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
+++ b/pages/learning-bitmark/quick-start/working-with-bitmarks/working-with-bitmark.md
@@ -1,13 +1,13 @@
 ---
-title: General concepts
+title: Working with Bitmark
 keywords: bitmark, account, transaction
 last_updated: 
 sidebar: mydoc_sidebar
-permalink: /learning-bitmark/quick-start/working-with-bitmarks/general-concepts
+permalink: /learning-bitmark/quick-start/working-with-bitmark
 folder: learning-bitmark/quick-start/working-with-bitmarks
 ---
 
-# General concepts
+# Working with Bitmark
 
 ## Bitmark Account
 
@@ -52,7 +52,7 @@ Once an asset has been registered, the owner can trade it by creating a transfer
 
 Bitmark owners can transfer their Bitmark Certificates to others using the [Bitmark App](using-bitmark-app.md#transferring-bitmark-certificates), the [SDK](using-sdk.md#transferring-bitmark-certificates), or the [CLI](using-cli.md#transferring-bitmark-certificates).
 
-### Bitmark shares
+## Bitmark shares
 
 In some cases, the ownership of a property is shared between different parties or people. To support these situations, the Bitmark Property System provides a feature called **[Bitmark shares](https://docs.bitmark.com/bitmark-appendix/bitmark-shares)**.
 


### PR DESCRIPTION
- [ ] Update the document 1st headings as titles to make them align with the navigation menus

- [ ] Rewrite & reorder the sections related to executing bitmark transactions ( creating an account, registering and transferring certificates, using bitmark shares...) in Learning Bitmark/ Quick Start section. 
@shannona, @nodestory: From the CTBC feedbacks, we don't want to keep the sections organized by functions as currently, we would like to order them by tools:
- We no longer use the file files: creating-bitmark-account.md, issuing-bitmark.md, transferring-bitmark.md.
- We use files: working-with-bitmark.md (general definitions), using-bitmark-app.md (how to execute transactions using Bitmark app), using-sdk.md(how to execute transactions using SDK), using-cli.md(how to execute transactions using CLI), payment-for-bitmark-cli.md (Install and setup bitmark wallet), using-bitmark-shares.md (how to execute transactions of bitmark shares)
- The re-organizing is described in https://docs.google.com/document/d/1_miT8taHdQsi-wUXTmNxyJ4RZq3-T42dRqvog-crsoo

- [ ] Update the mydoc_sidebar.yml to reflect the content changes. 